### PR TITLE
Obstacle detection, oscillation recovery and new parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED
 		geometry_msgs
 		std_msgs
 		message_generation
+        base_local_planner
         )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(catkin REQUIRED
 		geometry_msgs
 		std_msgs
 		message_generation
-        base_local_planner
         )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ catkin_package(
 )
 
 add_library(ftc_local_planner 
-	    src/ftc_planner.cpp)
+	    src/ftc_planner.cpp
+        src/recovery_behaviors.cpp)
 target_link_libraries(ftc_local_planner ${catkin_LIBRARIES})
 add_dependencies(ftc_local_planner ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(ftc_local_planner ftc_local_planner_gencfg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # FTCLocalPlanner
 
-A very simple "follow the carrot" local planner implementation.
+This repository contains a very simple "follow the carrot" local planner implementation.
 
+## Description
+The planner follows a given path as exactly as possible. It calculate the position of the carrot by
+taking robots velocity limits into account. If deviation between carrot and robot is above a given
+threshold, the planner stops.
 
+Also it checks for collisions of carrot with obstacles as well as collisions of robot footprint at actual robot pose. It doesn't implement obstacle aviodance but obstacle detection. Following situation will cause the 
+planner to exit:
+- goal reached
+- goal (pose) timeout reached
+- deviation between carrot and robot 
+- collision of carrot with obstacles
+- collision of robot footprint with obstacles
+
+## Published Topics
+- **`global_point`** (geometry_msgs/PoseStamped) pose of carrot
+- **`global_plan`** (nav_msgs/Path) global path to follow
+- **`debug_pid`** (ftc_local_planner/PID) debug information of PID calculation
+- **`costmap_marker`** (visualization_msgs/Marker) debug information of costmap check
 

--- a/cfg/FTCPlanner.cfg
+++ b/cfg/FTCPlanner.cfg
@@ -52,6 +52,8 @@ grp_recovery.add("oscillation_recovery_min_duration", double_t, 0, "duration unt
 # Obstacles
 grp_obstacles = gen.add_group("obstacles", type="tab")   
 grp_obstacles.add("check_obstacles", bool_t, 0, "check and stop for obstacles in path", True)
+grp_obstacles.add("obstacle_lookahead", int_t, 0, "how many path segments should be used for collision check", 5,0,20)
+grp_obstacles.add("obstacle_footprint", bool_t, 0, "check footprint at actual pose for collision", True)
 grp_obstacles.add("debug_obstacle", bool_t, 0, "debug obstacle check as marker array", True)
 
 exit(gen.generate("ftc_local_planner", "ftc_local_planner", "FTCPlanner"))

--- a/cfg/FTCPlanner.cfg
+++ b/cfg/FTCPlanner.cfg
@@ -4,39 +4,53 @@ from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, d
 
 gen = ParameterGenerator()
 
-gen.add("speed_fast", double_t, 0, "The max speed with which the control point is moved along the path if the straight distance is larger than speed_fast_threshold", 0.5, 0, 2.0)
-gen.add("speed_fast_threshold", double_t, 0, "Min straight distance in front of the robot for fast speed to be used", 1.5, 0, 5.0)
-gen.add("speed_fast_threshold_angle", double_t, 0, "Max angle between current pose and pose on path to still count as straight line", 5.0, 0, 45.0)
-gen.add("speed_slow", double_t, 0, "Slow speed", 0.2, 0, 2.0)
-gen.add("speed_angular", double_t, 0, "The max angular speed with which the control point is moved along the path", 20.0, 1.0, 150.0)
-gen.add("acceleration", double_t, 0, "Acceleration for speed transition", 1.0, 0, 10.0)
+grp_cp = gen.add_group("ControlPoint", type="tab") 
+grp_cp.add("speed_fast", double_t, 0, "The max speed with which the control point is moved along the path if the straight distance is larger than speed_fast_threshold", 0.5, 0, 2.0)
+grp_cp.add("speed_fast_threshold", double_t, 0, "Min straight distance in front of the robot for fast speed to be used", 1.5, 0, 5.0)
+grp_cp.add("speed_fast_threshold_angle", double_t, 0, "Max angle between current pose and pose on path to still count as straight line", 5.0, 0, 45.0)
+grp_cp.add("speed_slow", double_t, 0, "Slow speed", 0.2, 0, 2.0)
+grp_cp.add("speed_angular", double_t, 0, "The max angular speed with which the control point is moved along the path", 20.0, 1.0, 150.0)
+grp_cp.add("acceleration", double_t, 0, "Acceleration for speed transition", 1.0, 0, 10.0)
 
+grp_pid = gen.add_group("PID", type="tab") 
+grp_pid.add("kp_lon", double_t, 0, "KP for speed controller lon", 1.0, 0.0, 50.0)
+grp_pid.add("ki_lon", double_t, 0, "KI for speed controller lon", 0.0, 0.0, 1.0)
+grp_pid.add("ki_lon_max", double_t, 0, "KI windup for speed controller lon", 10.0, 0.0, 100.0)
+grp_pid.add("kd_lon", double_t, 0, "KD for speed controller lon", 0.0, 0.0, 1.0)
+grp_pid.add("ki_lat", double_t, 0, "KI for speed controller lat", 0.0, 0.0, 5.0)
+grp_pid.add("ki_lat_max", double_t, 0, "KI windup for speed controller lat", 10.0, 0.0, 500.0)
+grp_pid.add("kp_lat", double_t, 0, "KP for speed controller lat", 1.0, 0.0, 250.0)
+grp_pid.add("kd_lat", double_t, 0, "KD for speed controller lat", 0.0, 0.0, 5.0)
+grp_pid.add("kp_ang", double_t, 0, "KP for angle controller", 1.0, 0.0, 50.0)
+grp_pid.add("ki_ang", double_t, 0, "KI for angle controller", 0.0, 0.0, 5.0)
+grp_pid.add("ki_ang_max", double_t, 0, "KI windup for speed controller angle", 10.0, 0.0, 500.0)
+grp_pid.add("kd_ang", double_t, 0, "KD for angle controller", 0.0, 0.0, 5.0)
 
-gen.add("kp_lon", double_t, 0, "KP for speed controller lon", 1.0, 0.0, 50.0)
-gen.add("ki_lon", double_t, 0, "KI for speed controller lon", 0.0, 0.0, 1.0)
-gen.add("ki_lon_max", double_t, 0, "KI windup for speed controller lon", 10.0, 0.0, 100.0)
-gen.add("kd_lon", double_t, 0, "KD for speed controller lon", 0.0, 0.0, 1.0)
-gen.add("ki_lat", double_t, 0, "KI for speed controller lat", 0.0, 0.0, 5.0)
-gen.add("ki_lat_max", double_t, 0, "KI windup for speed controller lat", 10.0, 0.0, 500.0)
-gen.add("kp_lat", double_t, 0, "KP for speed controller lat", 1.0, 0.0, 250.0)
-gen.add("kd_lat", double_t, 0, "KD for speed controller lat", 0.0, 0.0, 5.0)
-gen.add("kp_ang", double_t, 0, "KP for angle controller", 1.0, 0.0, 50.0)
-gen.add("ki_ang", double_t, 0, "KI for angle controller", 0.0, 0.0, 5.0)
-gen.add("ki_ang_max", double_t, 0, "KI windup for speed controller angle", 10.0, 0.0, 500.0)
-gen.add("kd_ang", double_t, 0, "KD for angle controller", 0.0, 0.0, 5.0)
-
-
-gen.add("max_cmd_vel_speed", double_t, 0, "Max speed to send to the controller", 2.0, 0.0, 5.0)
-gen.add("max_cmd_vel_ang", double_t, 0, "Max angular speed to send to the controller", 2.0, 0.0, 5.0)
-gen.add("max_goal_distance_error", double_t, 0, "Wait for robot to get closer than max_goal_distance_error to the goal before setting goal as finished", 1.0, 0.0, 3.0)
-gen.add("max_goal_angle_error", double_t, 0, "Wait for robot to get a better angle than max_goal_angle_error before setting goal as finished", 10.0, 0.0, 360.0)
-gen.add("goal_timeout", double_t, 0, "Timeout for max_goal_distance_error and max_goal_angle_error", 5.0, 0.0, 100.0)
-gen.add("max_follow_distance", double_t, 0, "Stop controller if robot is further away than max_follow_distance (i.e. crash detection)", 1.0, 0.0, 3.0)
+grp_bot = gen.add_group("Robot", type="tab") 
+grp_bot.add("max_cmd_vel_speed", double_t, 0, "Max speed to send to the controller", 2.0, 0.0, 5.0)
+grp_bot.add("max_cmd_vel_ang", double_t, 0, "Max angular speed to send to the controller", 2.0, 0.0, 5.0)
+grp_bot.add("max_goal_distance_error", double_t, 0, "Wait for robot to get closer than max_goal_distance_error to the goal before setting goal as finished", 1.0, 0.0, 3.0)
+grp_bot.add("max_goal_angle_error", double_t, 0, "Wait for robot to get a better angle than max_goal_angle_error before setting goal as finished", 10.0, 0.0, 360.0)
+grp_bot.add("goal_timeout", double_t, 0, "Timeout for max_goal_distance_error and max_goal_angle_error", 5.0, 0.0, 100.0)
+grp_bot.add("max_follow_distance", double_t, 0, "Stop controller if robot is further away than max_follow_distance (i.e. crash detection)", 1.0, 0.0, 3.0)
 
 
 
 gen.add("forward_only", bool_t, 0, "Only allow forward driving", True)
 gen.add("restore_defaults", bool_t, 0, " Load default config", False)
 gen.add("debug_pid", bool_t, 0, " Emit debug_pid topic", False)
+
+# Recovery
+grp_recovery = gen.add_group("recovery", type="tab")   
+grp_recovery.add("oscillation_recovery",   bool_t,   0,
+  "Try to detect and resolve oscillations between multiple solutions in the same equivalence class (robot frequently switches between left/right/forward/backwards).",
+  True) 
+grp_recovery.add("oscillation_v_eps", double_t, 0, "Oscillation velocity eps", 5.0, 0.0, 100.0)
+grp_recovery.add("oscillation_omega_eps", double_t, 0, "Oscillation omega eps", 5.0, 0.0, 100.0)
+grp_recovery.add("oscillation_recovery_min_duration", double_t, 0, "duration until recovery in s", 5.0, 0.0, 100.0)
+
+# Obstacles
+grp_obstacles = gen.add_group("obstacles", type="tab")   
+grp_obstacles.add("check_obstacles", bool_t, 0, "check and stop for obstacles in path", True)
 
 exit(gen.generate("ftc_local_planner", "ftc_local_planner", "FTCPlanner"))

--- a/cfg/FTCPlanner.cfg
+++ b/cfg/FTCPlanner.cfg
@@ -52,5 +52,6 @@ grp_recovery.add("oscillation_recovery_min_duration", double_t, 0, "duration unt
 # Obstacles
 grp_obstacles = gen.add_group("obstacles", type="tab")   
 grp_obstacles.add("check_obstacles", bool_t, 0, "check and stop for obstacles in path", True)
+grp_obstacles.add("debug_obstacle", bool_t, 0, "debug obstacle check as marker array", True)
 
 exit(gen.generate("ftc_local_planner", "ftc_local_planner", "FTCPlanner"))

--- a/include/ftc_local_planner/ftc_planner.h
+++ b/include/ftc_local_planner/ftc_planner.h
@@ -22,6 +22,7 @@
 #include "tf2_eigen/tf2_eigen.h"
 #include <mbf_costmap_core/costmap_controller.h>
 #include <visualization_msgs/Marker.h>
+#include <base_local_planner/costmap_model.h>
 
 namespace ftc_local_planner
 {
@@ -50,9 +51,13 @@ namespace ftc_local_planner
 
         tf2_ros::Buffer *tf_buffer;
         costmap_2d::Costmap2DROS *costmap;
-        costmap_2d::Costmap2D *costmap_map_;
-        std::vector<geometry_msgs::PoseStamped> global_plan;
+        costmap_2d::Costmap2D* costmap_map_;
+        std::vector<geometry_msgs::Point> footprint_spec_; //!< Store the footprint of the robot
+        double robot_inscribed_radius_;                    //!< The radius of the inscribed circle of the robot (collision possible)
+        double robot_circumscribed_radius_;                //!< The radius of the circumscribed circle of the robot
+        base_local_planner::CostmapModel *costmap_model_; 
 
+        std::vector<geometry_msgs::PoseStamped> global_plan;
         ros::Publisher global_point_pub;
         ros::Publisher global_plan_pub;
         ros::Publisher progress_pub;
@@ -126,6 +131,9 @@ namespace ftc_local_planner
          * @return sum of `values`, or 0.0 if `values` is empty.
          */
         void debugObstacle(visualization_msgs::Marker &obstacle_points, double x, double y, unsigned char cost, int maxIDs);
+
+        bool isTrajectoryFeasible(base_local_planner::CostmapModel *costmap_model, const std::vector<geometry_msgs::Point> &footprint_spec,
+                                  double inscribed_radius, double circumscribed_radius, int look_ahead_idx); //, double feasibility_check_lookahead_distance)
 
         double time_in_current_state()
         {

--- a/include/ftc_local_planner/ftc_planner.h
+++ b/include/ftc_local_planner/ftc_planner.h
@@ -50,9 +50,7 @@ namespace ftc_local_planner
 
         tf2_ros::Buffer *tf_buffer;
         costmap_2d::Costmap2DROS *costmap;
-        costmap_2d::Costmap2D* costmap_map_;
-        std::vector<geometry_msgs::Point> footprint_spec_; //!< Store the footprint of the robot
-     
+        costmap_2d::Costmap2D* costmap_map_;   
 
         std::vector<geometry_msgs::PoseStamped> global_plan;
         ros::Publisher global_point_pub;

--- a/include/ftc_local_planner/ftc_planner.h
+++ b/include/ftc_local_planner/ftc_planner.h
@@ -21,6 +21,7 @@
 #include <Eigen/Geometry>
 #include "tf2_eigen/tf2_eigen.h"
 #include <mbf_costmap_core/costmap_controller.h>
+#include <visualization_msgs/Marker.h>
 
 namespace ftc_local_planner
 {
@@ -49,11 +50,13 @@ namespace ftc_local_planner
 
         tf2_ros::Buffer *tf_buffer;
         costmap_2d::Costmap2DROS *costmap;
+        costmap_2d::Costmap2D *costmap_map_;
         std::vector<geometry_msgs::PoseStamped> global_plan;
 
         ros::Publisher global_point_pub;
         ros::Publisher global_plan_pub;
         ros::Publisher progress_pub;
+        ros::Publisher obstacle_marker_pub;
 
         FTCPlannerConfig config;
 
@@ -96,8 +99,33 @@ namespace ftc_local_planner
         PlannerState update_planner_state();
         void update_control_point(double dt);
         void calculate_velocity_commands(double dt, geometry_msgs::TwistStamped &cmd_vel);
+
+        /**
+         * @brief check for obstacles in path
+         * @param max_points number of path segments (of global path) to check
+         * @return true if collision will happen.
+         */
         bool checkCollision(int max_points);
+
+        /**
+         * @brief check if robot oscillates (only angular). Can be used to do some recovery
+         * @param cmd_vel last velocity message send to robot
+         * @return true if robot oscillates
+         */
         bool checkOscillation(geometry_msgs::TwistStamped &cmd_vel);
+
+        /**
+         * @brief publish obstacles on path as marker array.
+         * @brief If obstacle_points contains more elements than maxID, marker gets published and
+         * @brief cleared afterwards.
+         * @param obstacle_points already collected points to visualize
+         * @param x X position in costmap
+         * @param y Y position in costmap
+         * @param cost cost value of cell
+         * @param maxIDs num of markers before publishing
+         * @return sum of `values`, or 0.0 if `values` is empty.
+         */
+        void debugObstacle(visualization_msgs::Marker &obstacle_points, double x, double y, unsigned char cost, int maxIDs);
 
         double time_in_current_state()
         {

--- a/include/ftc_local_planner/ftc_planner.h
+++ b/include/ftc_local_planner/ftc_planner.h
@@ -22,7 +22,6 @@
 #include "tf2_eigen/tf2_eigen.h"
 #include <mbf_costmap_core/costmap_controller.h>
 #include <visualization_msgs/Marker.h>
-#include <base_local_planner/costmap_model.h>
 
 namespace ftc_local_planner
 {
@@ -53,9 +52,7 @@ namespace ftc_local_planner
         costmap_2d::Costmap2DROS *costmap;
         costmap_2d::Costmap2D* costmap_map_;
         std::vector<geometry_msgs::Point> footprint_spec_; //!< Store the footprint of the robot
-        double robot_inscribed_radius_;                    //!< The radius of the inscribed circle of the robot (collision possible)
-        double robot_circumscribed_radius_;                //!< The radius of the circumscribed circle of the robot
-        base_local_planner::CostmapModel *costmap_model_; 
+     
 
         std::vector<geometry_msgs::PoseStamped> global_plan;
         ros::Publisher global_point_pub;
@@ -106,7 +103,7 @@ namespace ftc_local_planner
         void calculate_velocity_commands(double dt, geometry_msgs::TwistStamped &cmd_vel);
 
         /**
-         * @brief check for obstacles in path
+         * @brief check for obstacles in path as well as collision at actual pose
          * @param max_points number of path segments (of global path) to check
          * @return true if collision will happen.
          */
@@ -131,9 +128,6 @@ namespace ftc_local_planner
          * @return sum of `values`, or 0.0 if `values` is empty.
          */
         void debugObstacle(visualization_msgs::Marker &obstacle_points, double x, double y, unsigned char cost, int maxIDs);
-
-        bool isTrajectoryFeasible(base_local_planner::CostmapModel *costmap_model, const std::vector<geometry_msgs::Point> &footprint_spec,
-                                  double inscribed_radius, double circumscribed_radius, int look_ahead_idx); //, double feasibility_check_lookahead_distance)
 
         double time_in_current_state()
         {

--- a/include/ftc_local_planner/recovery_behaviors.h
+++ b/include/ftc_local_planner/recovery_behaviors.h
@@ -1,0 +1,136 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016,
+ *  TU Dortmund - Institute of Control Theory and Systems Engineering.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the institute nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Christoph Rösmann
+ *********************************************************************/
+
+#ifndef RECOVERY_BEHAVIORS_H__
+#define RECOVERY_BEHAVIORS_H__
+
+
+#include <boost/circular_buffer.hpp>
+#include <geometry_msgs/TwistStamped.h>
+#include <ros/ros.h>
+
+namespace ftc_local_planner
+{
+
+
+/**
+ * @class FailureDetector
+ * @brief This class implements methods in order to detect if the robot got stucked or is oscillating
+ * 
+ * The StuckDetector analyzes the last N commanded velocities in order to detect whether the robot
+ * might got stucked or oscillates between left/right/forward/backwards motions.
+ * 
+ * Taken from teb_local_planner
+ */  
+class FailureDetector
+{
+public:
+
+  /**
+   * @brief Default constructor
+   */
+  FailureDetector() {}  
+  
+  /**
+   * @brief destructor.
+   */
+  ~FailureDetector() {}
+  
+  /**
+   * @brief Set buffer length (measurement history)
+   * @param length number of measurements to be kept
+   */
+  void setBufferLength(int length) {buffer_.set_capacity(length);}
+  
+  /**
+   * @brief Add a new twist measurement to the internal buffer and compute a new decision
+   * @param twist geometry_msgs::TwistStamped velocity information
+   * @param v_max maximum forward translational velocity
+   * @param v_backwards_max maximum backward translational velocity
+   * @param omega_max maximum angular velocity 
+   * @param v_eps Threshold for the average normalized linear velocity in (0,1) that must not be exceded (e.g. 0.1)
+   * @param omega_eps Threshold for the average normalized angular velocity in (0,1) that must not be exceded (e.g. 0.1)
+   */
+  void update(const geometry_msgs::TwistStamped &twist, double v_max, double v_backwards_max, double omega_max, double v_eps, double omega_eps);
+  
+  /**
+   * @brief Check if the robot got stucked
+   * 
+   * This call does not compute the actual decision,
+   * since it is computed within each update() invocation.
+   * @return true if the robot got stucked, false otherwise.
+   */
+  bool isOscillating() const;
+  
+  /**
+   * @brief Clear the current internal state
+   * 
+   * This call also resets the internal buffer
+   */
+  void clear();
+       
+protected:
+    
+    /** Variables to be monitored */
+    struct VelMeasurement
+    {
+        double v = 0;
+        double omega = 0;
+    };
+    
+    /**
+     * @brief Detect if the robot got stucked based on the current buffer content
+     * 
+     * Afterwards the status might be checked using gotStucked();
+     * @param v_eps Threshold for the average normalized linear velocity in (0,1) that must not be exceded (e.g. 0.1)
+     * @param omega_eps Threshold for the average normalized angular velocity in (0,1) that must not be exceded (e.g. 0.1)
+     * @return true if the robot got stucked, false otherwise
+     */
+    bool detect(double v_eps, double omega_eps);
+  
+private:
+    
+    boost::circular_buffer<VelMeasurement> buffer_; //!< Circular buffer to store the last measurements @see setBufferLength
+    bool oscillating_ = false; //!< Current state: true if robot is oscillating
+                
+};
+
+
+} // namespace teb_local_planner
+
+#endif /* RECOVERY_BEHAVIORS_H__ */

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
     <build_depend>std_msgs</build_depend>
     <build_depend>message_generation</build_depend>
     <build_depend>tf2_eigen</build_depend>
+    <build_depend>base_local_planner</build_depend>
 
     <run_depend>tf2_ros</run_depend>
     <run_depend>tf2_geometry_msgs</run_depend>
@@ -39,9 +40,8 @@
     <run_depend>message_runtime</run_depend>
     <run_depend>std_msgs</run_depend>
     <run_depend>tf2_eigen</run_depend>
+    <run_depend>base_local_planner</run_depend>
 
     <export><mbf_costmap_core plugin="${prefix}/mbf_plugin.xml"/></export>
 
 </package>
-
-

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,6 @@
     <build_depend>std_msgs</build_depend>
     <build_depend>message_generation</build_depend>
     <build_depend>tf2_eigen</build_depend>
-    <build_depend>base_local_planner</build_depend>
 
     <run_depend>tf2_ros</run_depend>
     <run_depend>tf2_geometry_msgs</run_depend>
@@ -40,7 +39,6 @@
     <run_depend>message_runtime</run_depend>
     <run_depend>std_msgs</run_depend>
     <run_depend>tf2_eigen</run_depend>
-    <run_depend>base_local_planner</run_depend>
 
     <export><mbf_costmap_core plugin="${prefix}/mbf_plugin.xml"/></export>
 

--- a/src/ftc_planner.cpp
+++ b/src/ftc_planner.cpp
@@ -32,6 +32,12 @@ namespace ftc_local_planner
         costmap_map_ = costmap_ros->getCostmap();
         tf_buffer = tf;
 
+        // Get footprint of the robot and minimum and maximum distance from the center of the robot to its footprint vertices.
+        footprint_spec_ = costmap->getRobotFootprint();
+        costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius_);
+
+        costmap_model_ = new base_local_planner::CostmapModel(*costmap_map_);
+
         // Parameter for dynamic reconfigure
         reconfig_server = new dynamic_reconfigure::Server<FTCPlannerConfig>(private_nh);
         dynamic_reconfigure::Server<FTCPlannerConfig>::CallbackType cb = boost::bind(&FTCPlanner::reconfigureCB, this,
@@ -179,13 +185,23 @@ namespace ftc_local_planner
             current_state = new_planner_state;
         }
 
-        if (checkCollision(5))
+        // if (checkCollision(5))
+        // {
+        //     cmd_vel.twist.linear.x = 0;
+        //     cmd_vel.twist.angular.z = 0;
+        //     is_crashed = true;
+        //     return RET_BLOCKED;
+        // }
+footprint_spec_ = costmap->getRobotFootprint();
+costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius_);
+        if (!isTrajectoryFeasible(costmap_model_, footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius_, 5))
         {
             cmd_vel.twist.linear.x = 0;
             cmd_vel.twist.angular.z = 0;
             is_crashed = true;
             return RET_BLOCKED;
         }
+
         // Finally, we calculate the velocity commands.
         calculate_velocity_commands(dt, cmd_vel);
 
@@ -595,7 +611,7 @@ namespace ftc_local_planner
         for (int i = 0; i < max_points; i++)
         {
             geometry_msgs::PoseStamped x_pose;
-            
+
             x_pose = global_plan[current_index + i];
 
             unsigned int x;
@@ -688,6 +704,12 @@ namespace ftc_local_planner
         {
             obstacle_points.color.g = 1.0f;
         }
+
+        if (cost >= 127 && cost < 255)
+        {
+            obstacle_points.color.g = 0.5f;
+            obstacle_points.color.r = 0.5f;
+        }
         else
         {
             obstacle_points.color.r = 1.0f;
@@ -697,12 +719,96 @@ namespace ftc_local_planner
         costmap_map_->mapToWorld(x, y, p.x, p.y);
         p.z = 0;
 
+        // debug footprint
+
+
         obstacle_points.points.push_back(p);
-        if (obstacle_points.points.size() >= maxIDs)
+        if (obstacle_points.points.size() >= maxIDs || cost > 0)
         {
             obstacle_marker_pub.publish(obstacle_points);
             obstacle_points.points.clear();
         }
+    }
+
+    bool FTCPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel *costmap_model, const std::vector<geometry_msgs::Point> &footprint_spec,
+                                          double inscribed_radius, double circumscribed_radius, int look_ahead_idx) //, double feasibility_check_lookahead_distance)
+    {
+        visualization_msgs::Marker obstacle_marker;
+        // ensure look ahead not out of plan
+        if (global_plan.size() < look_ahead_idx)
+        {
+            look_ahead_idx = global_plan.size();
+        }
+        for (int i = 0; i <= look_ahead_idx; ++i)
+        {
+            geometry_msgs::PoseStamped x_pose;
+            int index = current_index + i;
+            if (index > global_plan.size())
+            {
+                index = global_plan.size();
+            }
+            x_pose = global_plan[index];
+            unsigned int x;
+            unsigned int y;
+            if (costmap_map_->worldToMap(x_pose.pose.position.x, x_pose.pose.position.y, x, y))
+            {
+             
+                double costs = costmap_model->footprintCost(x_pose.pose.position, footprint_spec, inscribed_radius, circumscribed_radius);
+                if (config.debug_obstacle)
+                {
+
+                    if (costs > 0)
+                    {
+                        debugObstacle(obstacle_marker, x, y, 0, look_ahead_idx);
+                    }
+                    if (costs == -3) // off map
+                    {
+                        debugObstacle(obstacle_marker, x, y, 127, look_ahead_idx);
+                    }
+                    if (costs == -1) // collission
+                    {
+                        debugObstacle(obstacle_marker, x, y, 255, look_ahead_idx);
+                    }                    
+                }
+                if (costs == -1)
+                {
+                    ROS_WARN("FTCLocalPlannerROS: Possible collision. Stop local planner.");
+                    return false;
+                }
+                // Checks if the distance between two poses is higher than the robot radius or the orientation diff is bigger than the specified threshold
+                // and interpolates in that case.
+                // (if obstacles are pushing two consecutive poses away, the center between two consecutive poses might coincide with the obstacle ;-)!
+                // if (i < look_ahead_idx)
+                // {
+                //     double delta_rot = g2o::normalize_theta(g2o::normalize_theta(teb().Pose(i + 1).theta()) -
+                //                                             g2o::normalize_theta(teb().Pose(i).theta()));
+                //     Eigen::Vector2d delta_dist = teb().Pose(i + 1).position() - teb().Pose(i).position();
+                //     if (fabs(delta_rot) > cfg_->trajectory.min_resolution_collision_check_angular || delta_dist.norm() > inscribed_radius)
+                //     {
+                //         int n_additional_samples = std::max(std::ceil(fabs(delta_rot) / cfg_->trajectory.min_resolution_collision_check_angular),
+                //                                             std::ceil(delta_dist.norm() / inscribed_radius)) -
+                //                                    1;
+                //         PoseSE2 intermediate_pose = teb().Pose(i);
+                //         for (int step = 0; step < n_additional_samples; ++step)
+                //         {
+                //             intermediate_pose.position() = intermediate_pose.position() + delta_dist / (n_additional_samples + 1.0);
+                //             intermediate_pose.theta() = g2o::normalize_theta(intermediate_pose.theta() +
+                //                                                              delta_rot / (n_additional_samples + 1.0));
+                //             if (costmap_model->footprintCost(intermediate_pose.x(), intermediate_pose.y(), intermediate_pose.theta(),
+                //                                              footprint_spec, inscribed_radius, circumscribed_radius) == -1)
+                //             {
+                //                 if (visualization_)
+                //                 {
+                //                     visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_, footprint_spec);
+                //                 }
+                //                 return false;
+                //             }
+                //         }
+                //     }
+                // }
+            }
+        }
+        return true;
     }
 
 }

--- a/src/ftc_planner.cpp
+++ b/src/ftc_planner.cpp
@@ -179,7 +179,7 @@ namespace ftc_local_planner
             current_state = new_planner_state;
         }
 
-        if (checkCollision(5))
+        if (checkCollision(config.obstacle_lookahead))
         {
             cmd_vel.twist.linear.x = 0;
             cmd_vel.twist.angular.z = 0;
@@ -599,6 +599,8 @@ namespace ftc_local_planner
         }
 
         // calculate cost of footprint at robots actual pose
+        if (config.obstacle_footprint)
+        {
         costmap->getOrientedFootprint(footprint);
         for (int i = 0; i < footprint.size(); i++)
         {
@@ -612,6 +614,7 @@ namespace ftc_local_planner
                     return true;
                 }
             }
+        }
         }
 
         for (int i = 0; i < max_points; i++)

--- a/src/ftc_planner.cpp
+++ b/src/ftc_planner.cpp
@@ -6,21 +6,23 @@
 
 PLUGINLIB_EXPORT_CLASS(ftc_local_planner::FTCPlanner, mbf_costmap_core::CostmapController)
 
-
 #define RET_SUCCESS 0
 #define RET_COLLISION 104
+#define RET_BLOCKED 109
 
-namespace ftc_local_planner {
+namespace ftc_local_planner
+{
 
-    FTCPlanner::FTCPlanner() {
+    FTCPlanner::FTCPlanner()
+    {
     }
 
-    void FTCPlanner::initialize(std::string name, tf2_ros::Buffer *tf, costmap_2d::Costmap2DROS *costmap_ros) {
+    void FTCPlanner::initialize(std::string name, tf2_ros::Buffer *tf, costmap_2d::Costmap2DROS *costmap_ros)
+    {
         ros::NodeHandle private_nh("~/" + name);
 
         progress_server = private_nh.advertiseService(
-                "planner_get_progress",&FTCPlanner::getProgress, this);
-
+            "planner_get_progress", &FTCPlanner::getProgress, this);
 
         global_point_pub = private_nh.advertise<geometry_msgs::PoseStamped>("global_point", 1);
         global_plan_pub = private_nh.advertise<nav_msgs::Path>("global_plan", 1, true);
@@ -28,7 +30,7 @@ namespace ftc_local_planner {
         costmap = costmap_ros;
         tf_buffer = tf;
 
-        //Parameter for dynamic reconfigure
+        // Parameter for dynamic reconfigure
         reconfig_server = new dynamic_reconfigure::Server<FTCPlannerConfig>(private_nh);
         dynamic_reconfigure::Server<FTCPlannerConfig>::CallbackType cb = boost::bind(&FTCPlanner::reconfigureCB, this,
                                                                                      _1, _2);
@@ -39,14 +41,21 @@ namespace ftc_local_planner {
         // PID Debugging topic
         if (config.debug_pid)
         {
-            pubPid = private_nh.advertise<ftc_local_planner::PID>("debug_pid", 1, true);        
+            pubPid = private_nh.advertise<ftc_local_planner::PID>("debug_pid", 1, true);
         }
-        
-        ROS_INFO("FTCPlanner: Version 2 Init.");
+
+        // Recovery behavior initialization
+        failure_detector_.setBufferLength(std::round(config.oscillation_recovery_min_duration * 10));
+
+        ROS_INFO("FTCLocalPlannerROS: Version 2 Init.");
+        ROS_INFO_STREAM("FTCLocalPlannerROS: costmap frame ID: " << costmap->getGlobalFrameID());
+        ROS_INFO_STREAM("FTCLocalPlannerROS: costmap base frame ID: " << costmap->getBaseFrameID());
     }
 
-    void FTCPlanner::reconfigureCB(FTCPlannerConfig &c, uint32_t level) {
-        if (c.restore_defaults) {
+    void FTCPlanner::reconfigureCB(FTCPlannerConfig &c, uint32_t level)
+    {
+        if (c.restore_defaults)
+        {
             reconfig_server->getConfigDefault(c);
             c.restore_defaults = false;
         }
@@ -54,9 +63,13 @@ namespace ftc_local_planner {
 
         // just to be sure
         current_movement_speed = config.speed_slow;
+
+        // set recovery behavior
+        failure_detector_.setBufferLength(std::round(config.oscillation_recovery_min_duration * 10));
     }
 
-    bool FTCPlanner::setPlan(const std::vector<geometry_msgs::PoseStamped> &plan) {
+    bool FTCPlanner::setPlan(const std::vector<geometry_msgs::PoseStamped> &plan)
+    {
         current_state = PRE_ROTATE;
         state_entered_time = ros::Time::now();
         is_crashed = false;
@@ -68,7 +81,6 @@ namespace ftc_local_planner {
         last_time = ros::Time::now();
         current_movement_speed = config.speed_slow;
 
-
         lat_error = 0.0;
         lon_error = 0.0;
         angle_error = 0.0;
@@ -78,45 +90,53 @@ namespace ftc_local_planner {
 
         nav_msgs::Path path;
 
-        if (global_plan.size() > 2) {
+        if (global_plan.size() > 2)
+        {
             // duplicate last point
             global_plan.push_back(global_plan.back());
             // give second from last point last oriantation as the point before that
             global_plan[global_plan.size() - 2].pose.orientation = global_plan[global_plan.size() - 3].pose.orientation;
             path.header = plan.front().header;
             path.poses = plan;
-        } else {
-            ROS_WARN_STREAM("Global plan was too short. Need a minimum of 3 poses - Cancelling.");
+        }
+        else
+        {
+            ROS_WARN_STREAM("FTCLocalPlannerROS: Global plan was too short. Need a minimum of 3 poses - Cancelling.");
             current_state = FINISHED;
             state_entered_time = ros::Time::now();
         }
         global_plan_pub.publish(path);
 
-        ROS_INFO_STREAM("Got new global plan with " << plan.size() << " points.");
+        ROS_INFO_STREAM("FTCLocalPlannerROS: Got new global plan with " << plan.size() << " points.");
 
         return true;
     }
 
-
-    FTCPlanner::~FTCPlanner() {
-        if (reconfig_server != nullptr) {
+    FTCPlanner::~FTCPlanner()
+    {
+        if (reconfig_server != nullptr)
+        {
             delete reconfig_server;
             reconfig_server = nullptr;
         }
     }
 
-    double FTCPlanner::distanceLookahead() {
-        if (global_plan.size() < 2) {
+    double FTCPlanner::distanceLookahead()
+    {
+        if (global_plan.size() < 2)
+        {
             return 0;
         }
         Eigen::Quaternion<double> current_rot(current_control_point.linear());
 
         Eigen::Affine3d last_straight_point = current_control_point;
-        for (uint32_t i = current_index + 1; i < global_plan.size(); i++) {
+        for (uint32_t i = current_index + 1; i < global_plan.size(); i++)
+        {
             tf2::fromMsg(global_plan[i].pose, last_straight_point);
             // check, if direction is the same. if so, we add the distance
             Eigen::Quaternion<double> rot2(last_straight_point.linear());
-            if (abs(rot2.angularDistance(current_rot)) > config.speed_fast_threshold_angle * (M_PI / 180.0)) {
+            if (abs(rot2.angularDistance(current_rot)) > config.speed_fast_threshold_angle * (M_PI / 180.0))
+            {
                 break;
             }
         }
@@ -126,19 +146,22 @@ namespace ftc_local_planner {
 
     uint32_t FTCPlanner::computeVelocityCommands(const geometry_msgs::PoseStamped &pose,
                                                  const geometry_msgs::TwistStamped &velocity,
-                                                 geometry_msgs::TwistStamped &cmd_vel, std::string &message) {
+                                                 geometry_msgs::TwistStamped &cmd_vel, std::string &message)
+    {
 
         ros::Time now = ros::Time::now();
         double dt = now.toSec() - last_time.toSec();
         last_time = now;
 
-        if (is_crashed) {
+        if (is_crashed)
+        {
             cmd_vel.twist.linear.x = 0;
             cmd_vel.twist.angular.z = 0;
             return RET_COLLISION;
         }
 
-        if (current_state == FINISHED) {
+        if (current_state == FINISHED)
+        {
             cmd_vel.twist.linear.x = 0;
             cmd_vel.twist.angular.z = 0;
             return RET_SUCCESS;
@@ -149,16 +172,25 @@ namespace ftc_local_planner {
         update_control_point(dt);
         // Then, update the planner state.
         auto new_planner_state = update_planner_state();
-        if (new_planner_state != current_state) {
-            ROS_INFO_STREAM("Switching to state " << new_planner_state);
+        if (new_planner_state != current_state)
+        {
+            ROS_INFO_STREAM("FTCLocalPlannerROS: Switching to state " << new_planner_state);
             state_entered_time = ros::Time::now();
             current_state = new_planner_state;
         }
 
+        if (checkCollision(5))
+        {
+            cmd_vel.twist.linear.x = 0;
+            cmd_vel.twist.angular.z = 0;
+            is_crashed = true;
+            return RET_BLOCKED;
+        }
         // Finally, we calculate the velocity commands.
         calculate_velocity_commands(dt, cmd_vel);
 
-        if (is_crashed) {
+        if (is_crashed)
+        {
             cmd_vel.twist.linear.x = 0;
             cmd_vel.twist.angular.z = 0;
             return RET_COLLISION;
@@ -167,179 +199,210 @@ namespace ftc_local_planner {
         return RET_SUCCESS;
     }
 
-    bool FTCPlanner::isGoalReached(double dist_tolerance, double angle_tolerance) {
+    bool FTCPlanner::isGoalReached(double dist_tolerance, double angle_tolerance)
+    {
         return current_state == FINISHED;
     }
 
-    bool FTCPlanner::cancel() {
-        ROS_WARN_STREAM("FTC planner was cancelled.");
+    bool FTCPlanner::cancel()
+    {
+        ROS_WARN_STREAM("FTCLocalPlannerROS: FTC planner was cancelled.");
         current_state = FINISHED;
         state_entered_time = ros::Time::now();
         return true;
     }
 
-    FTCPlanner::PlannerState FTCPlanner::update_planner_state() {
-        switch (current_state) {
-            case PRE_ROTATE: {
-                if (time_in_current_state() > config.goal_timeout) {
-                    ROS_ERROR_STREAM("Error reaching goal. config.goal_timeout (" << config.goal_timeout << ") reached - Timeout in PRE_ROTATE phase.");
-                    is_crashed = true;
-                    return FINISHED;
-                }
-                if (abs(angle_error) * (180.0 / M_PI) < config.max_goal_angle_error) {
-                    ROS_INFO_STREAM("PRE_ROTATE finished. Starting following");
-                    return FOLLOWING;
-                }
+    FTCPlanner::PlannerState FTCPlanner::update_planner_state()
+    {
+        switch (current_state)
+        {
+        case PRE_ROTATE:
+        {
+            if (time_in_current_state() > config.goal_timeout)
+            {
+                ROS_ERROR_STREAM("FTCLocalPlannerROS: Error reaching goal. config.goal_timeout (" << config.goal_timeout << ") reached - Timeout in PRE_ROTATE phase.");
+                is_crashed = true;
+                return FINISHED;
             }
-                break;
-            case FOLLOWING: {
-                double distance = local_control_point.translation().norm();
-                // check for crash
-                if (distance > config.max_follow_distance) {
-                    ROS_ERROR_STREAM("Robot is far away from global plan. distance (" << distance << ") > config.max_follow_distance (" << config.max_follow_distance << ") It probably has crashed.");
-                    is_crashed = true;
-                    return FINISHED;
-                }
+            if (abs(angle_error) * (180.0 / M_PI) < config.max_goal_angle_error)
+            {
+                ROS_INFO_STREAM("FTCLocalPlannerROS: PRE_ROTATE finished. Starting following");
+                return FOLLOWING;
+            }
+        }
+        break;
+        case FOLLOWING:
+        {
+            double distance = local_control_point.translation().norm();
+            // check for crash
+            if (distance > config.max_follow_distance)
+            {
+                ROS_ERROR_STREAM("FTCLocalPlannerROS: Robot is far away from global plan. distance (" << distance << ") > config.max_follow_distance (" << config.max_follow_distance << ") It probably has crashed.");
+                is_crashed = true;
+                return FINISHED;
+            }
 
-                // check if we're done following
-                if (current_index == global_plan.size() - 2) {
-                    ROS_INFO_STREAM("switching planner to position mode");
-                    return WAITING_FOR_GOAL_APPROACH;
-                }
+            // check if we're done following
+            if (current_index == global_plan.size() - 2)
+            {
+                ROS_INFO_STREAM("FTCLocalPlannerROS: switching planner to position mode");
+                return WAITING_FOR_GOAL_APPROACH;
             }
-                break;
-            case WAITING_FOR_GOAL_APPROACH: {
-                double distance = local_control_point.translation().norm();
-                if (time_in_current_state() > config.goal_timeout) {
-                    ROS_WARN_STREAM("Could not reach goal position. config.goal_timeout (" << config.goal_timeout << ") reached - Attempting final rotation anyways.");
-                    return POST_ROTATE;
-                }
-                if (distance < config.max_goal_distance_error) {
-                    ROS_INFO_STREAM("Reached goal position.");
-                    return POST_ROTATE;
-                }
+        }
+        break;
+        case WAITING_FOR_GOAL_APPROACH:
+        {
+            double distance = local_control_point.translation().norm();
+            if (time_in_current_state() > config.goal_timeout)
+            {
+                ROS_WARN_STREAM("FTCLocalPlannerROS: Could not reach goal position. config.goal_timeout (" << config.goal_timeout << ") reached - Attempting final rotation anyways.");
+                return POST_ROTATE;
             }
-                break;
-            case POST_ROTATE: {
-                if (time_in_current_state() > config.goal_timeout) {
-                    ROS_WARN_STREAM("Could not reach goal rotation. config.goal_timeout (" << config.goal_timeout << ") reached");
-                    return FINISHED;
-                }
-                if (abs(angle_error) * (180.0 / M_PI) < config.max_goal_angle_error) {
-                    ROS_INFO_STREAM("POST_ROTATE finished.");
-                    return FINISHED;
-                }
+            if (distance < config.max_goal_distance_error)
+            {
+                ROS_INFO_STREAM("FTCLocalPlannerROS: Reached goal position.");
+                return POST_ROTATE;
             }
-                break;
-            case FINISHED: {
-                // Nothing to do here
+        }
+        break;
+        case POST_ROTATE:
+        {
+            if (time_in_current_state() > config.goal_timeout)
+            {
+                ROS_WARN_STREAM("FTCLocalPlannerROS: Could not reach goal rotation. config.goal_timeout (" << config.goal_timeout << ") reached");
+                return FINISHED;
             }
-                break;
+            if (abs(angle_error) * (180.0 / M_PI) < config.max_goal_angle_error)
+            {
+                ROS_INFO_STREAM("FTCLocalPlannerROS: POST_ROTATE finished.");
+                return FINISHED;
+            }
+        }
+        break;
+        case FINISHED:
+        {
+            // Nothing to do here
+        }
+        break;
         }
 
         return current_state;
     }
 
-    void FTCPlanner::update_control_point(double dt) {
+    void FTCPlanner::update_control_point(double dt)
+    {
 
-        switch (current_state) {
-            case PRE_ROTATE:
-                tf2::fromMsg(global_plan[0].pose, current_control_point);
-                break;
-            case FOLLOWING: {
-                // Normal planner operation
-                double straight_dist = distanceLookahead();
-                double speed;
-                if (straight_dist >= config.speed_fast_threshold) {
-                    speed = config.speed_fast;
-                } else {
-                    speed = config.speed_slow;
-                }
+        switch (current_state)
+        {
+        case PRE_ROTATE:
+            tf2::fromMsg(global_plan[0].pose, current_control_point);
+            break;
+        case FOLLOWING:
+        {
+            // Normal planner operation
+            double straight_dist = distanceLookahead();
+            double speed;
+            if (straight_dist >= config.speed_fast_threshold)
+            {
+                speed = config.speed_fast;
+            }
+            else
+            {
+                speed = config.speed_slow;
+            }
 
-                if (speed > current_movement_speed) {
-                    // accelerate
-                    current_movement_speed += dt * config.acceleration;
-                    if (current_movement_speed > speed)
-                        current_movement_speed = speed;
-                } else if (speed < current_movement_speed) {
-                    // decelerate
-                    current_movement_speed -= dt * config.acceleration;
-                    if (current_movement_speed < speed)
-                        current_movement_speed = speed;
-                }
+            if (speed > current_movement_speed)
+            {
+                // accelerate
+                current_movement_speed += dt * config.acceleration;
+                if (current_movement_speed > speed)
+                    current_movement_speed = speed;
+            }
+            else if (speed < current_movement_speed)
+            {
+                // decelerate
+                current_movement_speed -= dt * config.acceleration;
+                if (current_movement_speed < speed)
+                    current_movement_speed = speed;
+            }
 
-                double distance_to_move = dt * current_movement_speed;
-                double angle_to_move = dt * config.speed_angular * (M_PI / 180.0);
+            double distance_to_move = dt * current_movement_speed;
+            double angle_to_move = dt * config.speed_angular * (M_PI / 180.0);
 
-                Eigen::Affine3d nextPose, currentPose;
-                while (angle_to_move > 0 && distance_to_move > 0 && current_index < global_plan.size() - 2) {
-
-                    tf2::fromMsg(global_plan[current_index].pose, currentPose);
-                    tf2::fromMsg(global_plan[current_index + 1].pose, nextPose);
-
-                    double pose_distance = (nextPose.translation() - currentPose.translation()).norm();
-
-                    Eigen::Quaternion<double> current_rot(currentPose.linear());
-                    Eigen::Quaternion<double> next_rot(nextPose.linear());
-
-                    double pose_distance_angular = current_rot.angularDistance(next_rot);
-
-                    if (pose_distance <= 0.0) {
-                        ROS_WARN_STREAM("Skipping duplicate point in global plan.");
-                        current_index++;
-                        continue;
-                    }
-
-                    double remaining_distance_to_next_pose = pose_distance * (1.0 - current_progress);
-                    double remaining_angular_distance_to_next_pose = pose_distance_angular * (1.0 - current_progress);
-
-
-                    if (remaining_distance_to_next_pose < distance_to_move &&
-                        remaining_angular_distance_to_next_pose < angle_to_move) {
-                        // we need to move further than the remaining distance_to_move. Skip to the next point and decrease distance_to_move.
-                        current_progress = 0.0;
-                        current_index++;
-                        distance_to_move -= remaining_distance_to_next_pose;
-                        angle_to_move -= remaining_angular_distance_to_next_pose;
-                    } else {
-                        // we cannot reach the next point yet, so we update the percentage
-                        double current_progress_distance =
-                                (pose_distance * current_progress + distance_to_move) / pose_distance;
-                        double current_progress_angle =
-                                (pose_distance_angular * current_progress + angle_to_move) / pose_distance_angular;
-                        current_progress = fmin(current_progress_angle, current_progress_distance);
-                        if (current_progress > 1.0) {
-                            ROS_WARN_STREAM("FTC PLANNER: Progress > 1.0");
-                            //                    current_progress = 1.0;
-                        }
-                        distance_to_move = 0;
-                        angle_to_move = 0;
-                    }
-                }
+            Eigen::Affine3d nextPose, currentPose;
+            while (angle_to_move > 0 && distance_to_move > 0 && current_index < global_plan.size() - 2)
+            {
 
                 tf2::fromMsg(global_plan[current_index].pose, currentPose);
                 tf2::fromMsg(global_plan[current_index + 1].pose, nextPose);
-                // interpolate between points
-                Eigen::Quaternion<double> rot1(currentPose.linear());
-                Eigen::Quaternion<double> rot2(nextPose.linear());
 
-                Eigen::Vector3d trans1 = currentPose.translation();
-                Eigen::Vector3d trans2 = nextPose.translation();
+                double pose_distance = (nextPose.translation() - currentPose.translation()).norm();
 
-                Eigen::Affine3d result;
-                result.translation() = (1.0 - current_progress) * trans1 + current_progress * trans2;
-                result.linear() = rot1.slerp(current_progress, rot2).toRotationMatrix();
+                Eigen::Quaternion<double> current_rot(currentPose.linear());
+                Eigen::Quaternion<double> next_rot(nextPose.linear());
 
-                current_control_point = result;
+                double pose_distance_angular = current_rot.angularDistance(next_rot);
+
+                if (pose_distance <= 0.0)
+                {
+                    ROS_WARN_STREAM("FTCLocalPlannerROS: Skipping duplicate point in global plan.");
+                    current_index++;
+                    continue;
+                }
+
+                double remaining_distance_to_next_pose = pose_distance * (1.0 - current_progress);
+                double remaining_angular_distance_to_next_pose = pose_distance_angular * (1.0 - current_progress);
+
+                if (remaining_distance_to_next_pose < distance_to_move &&
+                    remaining_angular_distance_to_next_pose < angle_to_move)
+                {
+                    // we need to move further than the remaining distance_to_move. Skip to the next point and decrease distance_to_move.
+                    current_progress = 0.0;
+                    current_index++;
+                    distance_to_move -= remaining_distance_to_next_pose;
+                    angle_to_move -= remaining_angular_distance_to_next_pose;
+                }
+                else
+                {
+                    // we cannot reach the next point yet, so we update the percentage
+                    double current_progress_distance =
+                        (pose_distance * current_progress + distance_to_move) / pose_distance;
+                    double current_progress_angle =
+                        (pose_distance_angular * current_progress + angle_to_move) / pose_distance_angular;
+                    current_progress = fmin(current_progress_angle, current_progress_distance);
+                    if (current_progress > 1.0)
+                    {
+                        ROS_WARN_STREAM("FTCLocalPlannerROS: FTC PLANNER: Progress > 1.0");
+                        //                    current_progress = 1.0;
+                    }
+                    distance_to_move = 0;
+                    angle_to_move = 0;
+                }
             }
-                break;
-            case POST_ROTATE:
-                tf2::fromMsg(global_plan[global_plan.size() - 1].pose, current_control_point);
-                break;
-            case WAITING_FOR_GOAL_APPROACH:
-                break;
-            case FINISHED:
-                break;
+
+            tf2::fromMsg(global_plan[current_index].pose, currentPose);
+            tf2::fromMsg(global_plan[current_index + 1].pose, nextPose);
+            // interpolate between points
+            Eigen::Quaternion<double> rot1(currentPose.linear());
+            Eigen::Quaternion<double> rot2(nextPose.linear());
+
+            Eigen::Vector3d trans1 = currentPose.translation();
+            Eigen::Vector3d trans2 = nextPose.translation();
+
+            Eigen::Affine3d result;
+            result.translation() = (1.0 - current_progress) * trans1 + current_progress * trans2;
+            result.linear() = rot1.slerp(current_progress, rot2).toRotationMatrix();
+
+            current_control_point = result;
+        }
+        break;
+        case POST_ROTATE:
+            tf2::fromMsg(global_plan[global_plan.size() - 1].pose, current_control_point);
+            break;
+        case WAITING_FOR_GOAL_APPROACH:
+            break;
+        case FINISHED:
+            break;
         }
 
         {
@@ -356,97 +419,130 @@ namespace ftc_local_planner {
         angle_error = local_control_point.rotation().eulerAngles(0, 1, 2).z();
     }
 
-    void FTCPlanner::calculate_velocity_commands(double dt, geometry_msgs::TwistStamped &cmd_vel) {
+    void FTCPlanner::calculate_velocity_commands(double dt, geometry_msgs::TwistStamped &cmd_vel)
+    {
         // check, if we're completely done
-        if (current_state == FINISHED || is_crashed) {
+        if (current_state == FINISHED || is_crashed)
+        {
             cmd_vel.twist.linear.x = 0;
             cmd_vel.twist.angular.z = 0;
             return;
         }
 
-
         i_lon_error += lon_error * dt;
         i_lat_error += lat_error * dt;
         i_angle_error += angle_error * dt;
 
-        if (i_lon_error > config.ki_lon_max) {
+        if (i_lon_error > config.ki_lon_max)
+        {
             i_lon_error = config.ki_lon_max;
-        } else if (i_lon_error < -config.ki_lon_max) {
+        }
+        else if (i_lon_error < -config.ki_lon_max)
+        {
             i_lon_error = -config.ki_lon_max;
         }
-        if (i_lat_error > config.ki_lat_max) {
+        if (i_lat_error > config.ki_lat_max)
+        {
             i_lat_error = config.ki_lat_max;
-        } else if (i_lat_error < -config.ki_lat_max) {
+        }
+        else if (i_lat_error < -config.ki_lat_max)
+        {
             i_lat_error = -config.ki_lat_max;
         }
-        if (i_angle_error > config.ki_ang_max) {
+        if (i_angle_error > config.ki_ang_max)
+        {
             i_angle_error = config.ki_ang_max;
-        } else if (i_angle_error < -config.ki_ang_max) {
+        }
+        else if (i_angle_error < -config.ki_ang_max)
+        {
             i_angle_error = -config.ki_ang_max;
         }
-
 
         double d_lat = (lat_error - last_lat_error) / dt;
         double d_lon = (lon_error - last_lon_error) / dt;
         double d_angle = (angle_error - last_angle_error) / dt;
 
-
         last_lat_error = lat_error;
         last_lon_error = lon_error;
         last_angle_error = angle_error;
 
-
         // allow linear movement only if in following state
 
-        if (current_state == FOLLOWING) {
+        if (current_state == FOLLOWING)
+        {
             double lin_speed = lon_error * config.kp_lon + i_lon_error * config.ki_lon + d_lon * config.kd_lon;
-            if (lin_speed < 0 && config.forward_only) {
+            if (lin_speed < 0 && config.forward_only)
+            {
                 lin_speed = 0;
-            } else {
-                if (lin_speed > config.max_cmd_vel_speed) {
+            }
+            else
+            {
+                if (lin_speed > config.max_cmd_vel_speed)
+                {
                     lin_speed = config.max_cmd_vel_speed;
-                } else if (lin_speed < -config.max_cmd_vel_speed) {
+                }
+                else if (lin_speed < -config.max_cmd_vel_speed)
+                {
                     lin_speed = -config.max_cmd_vel_speed;
                 }
 
-                if (lin_speed < 0) {
+                if (lin_speed < 0)
+                {
                     lat_error *= -1.0;
                 }
             }
             cmd_vel.twist.linear.x = lin_speed;
-        } else {
+        }
+        else
+        {
             cmd_vel.twist.linear.x = 0.0;
         }
 
-        if (current_state == FOLLOWING) {
+        if (current_state == FOLLOWING)
+        {
 
             double ang_speed = angle_error * config.kp_ang + i_angle_error * config.ki_ang + d_angle * config.kd_ang +
                                lat_error * config.kp_lat + i_lat_error * config.ki_lat + d_lat * config.kd_lat;
 
-
-            if (ang_speed > config.max_cmd_vel_ang) {
+            if (ang_speed > config.max_cmd_vel_ang)
+            {
                 ang_speed = config.max_cmd_vel_ang;
-            } else if (ang_speed < -config.max_cmd_vel_ang) {
+            }
+            else if (ang_speed < -config.max_cmd_vel_ang)
+            {
                 ang_speed = -config.max_cmd_vel_ang;
             }
 
             cmd_vel.twist.angular.z = ang_speed;
-        } else {
+        }
+        else
+        {
             double ang_speed = angle_error * config.kp_ang + i_angle_error * config.ki_ang + d_angle * config.kd_ang;
-
-            if (ang_speed > config.max_cmd_vel_ang) {
+            if (ang_speed > config.max_cmd_vel_ang)
+            {
                 ang_speed = config.max_cmd_vel_ang;
-            } else if (ang_speed < -config.max_cmd_vel_ang) {
+            }
+            else if (ang_speed < -config.max_cmd_vel_ang)
+            {
                 ang_speed = -config.max_cmd_vel_ang;
             }
+
             cmd_vel.twist.angular.z = ang_speed;
+
+            // check if robot oscillates
+            bool is_oscillating = checkOscillation(cmd_vel);
+            if (is_oscillating)
+            {
+                ang_speed = config.max_cmd_vel_ang;
+                cmd_vel.twist.angular.z = ang_speed;
+            }
         }
 
         if (config.debug_pid)
         {
             ftc_local_planner::PID debugPidMsg;
             debugPidMsg.kp_lon_set = lon_error;
-            
+
             // proportional
             debugPidMsg.kp_lat_set = lat_error * config.kp_lat;
             debugPidMsg.kp_lon_set = lon_error * config.kp_lon;
@@ -470,15 +566,99 @@ namespace ftc_local_planner {
             // speeds
             debugPidMsg.ang_speed = cmd_vel.twist.angular.z;
             debugPidMsg.lin_speed = cmd_vel.twist.linear.x;
-            
+
             pubPid.publish(debugPidMsg);
         }
     }
 
-    bool FTCPlanner::getProgress(PlannerGetProgressRequest &req, PlannerGetProgressResponse &res) {
+    bool FTCPlanner::getProgress(PlannerGetProgressRequest &req, PlannerGetProgressResponse &res)
+    {
         res.index = current_index;
         return true;
     }
 
+    bool FTCPlanner::checkCollision(int max_points)
+    {
+        if (!config.check_obstacles)
+        {
+            return false;
+        }
+        // maximal costs
+        unsigned char previous_cost = 255;
+        // ensure look ahead not out of plan
+        if (global_plan.size() < max_points)
+        {
+            max_points = global_plan.size();
+        }
+        for (int i = 0; i < max_points; i++)
+        {
+            geometry_msgs::PoseStamped x_pose;
+            x_pose = global_plan[i];
+
+            unsigned int x;
+            unsigned int y;
+            costmap->getCostmap()->worldToMap(x_pose.pose.position.x, x_pose.pose.position.y, x, y);
+            unsigned char costs = costmap->getCostmap()->getCost(x, y);
+            // Near at obstacel
+            if (costs > 0)
+            {
+                // Possible collision
+                if (costs > 127 && costs > previous_cost)
+                {
+                    ROS_WARN("FTCLocalPlannerROS: Possible collision. Stop local planner.");
+                    return true;
+                }
+            }
+            previous_cost = costs;
+        }
+        return false;
+    }
+
+    bool FTCPlanner::checkOscillation(geometry_msgs::TwistStamped &cmd_vel)
+    {
+        bool oscillating = false;
+        // detect and resolve oscillations
+        if (config.oscillation_recovery)
+        {
+            // oscillating = true;
+            double max_vel_theta = config.max_cmd_vel_ang;
+            double max_vel_current = config.max_cmd_vel_speed;
+
+            failure_detector_.update(cmd_vel, config.max_cmd_vel_speed, config.max_cmd_vel_speed, max_vel_theta,
+                                     config.oscillation_v_eps, config.oscillation_omega_eps);
+
+            oscillating = failure_detector_.isOscillating();
+
+            if (oscillating) // we are currently oscillating
+            {
+                if (!oscillation_detected_) // do we already know that robot oscillates?
+                {
+                    time_last_oscillation_ = ros::Time::now(); // save time when oscillation was detected
+                    oscillation_detected_ = true;
+                }
+                // calculate duration of actual oscillation
+                bool oscillation_duration_timeout = !((ros::Time::now() - time_last_oscillation_).toSec() < config.oscillation_recovery_min_duration); // check how long we oscillate
+                if (oscillation_duration_timeout)
+                {
+                    if (!oscillation_warning_) // ensure to send warning just once instead of spamming around
+                    {
+                        ROS_WARN("FTCLocalPlannerROS: possible oscillation (of the robot or its local plan) detected. Activating recovery strategy (prefer current turning direction during optimization).");
+                        oscillation_warning_ = true;
+                    }
+                    return true;
+                }
+                return false; // oscillating but timeout not reached
+            }
+            else
+            {
+                // not oscillating
+                time_last_oscillation_ = ros::Time::now(); // save time when oscillation was detected
+                oscillation_detected_ = false;
+                oscillation_warning_ = false;
+                return false;
+            }
+        }
+        return false; // no check for oscillation
+    }
 
 }

--- a/src/recovery_behaviors.cpp
+++ b/src/recovery_behaviors.cpp
@@ -1,0 +1,119 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016,
+ *  TU Dortmund - Institute of Control Theory and Systems Engineering.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the institute nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Christoph Rösmann
+ *********************************************************************/
+
+#include <ftc_local_planner/recovery_behaviors.h>
+#include <ros/ros.h>
+#include <limits>
+#include <functional>
+#include <numeric>
+#include <g2o/stuff/misc.h>
+
+namespace ftc_local_planner
+{
+
+// ============== FailureDetector Implementation ===================
+
+void FailureDetector::update(const geometry_msgs::TwistStamped& twist, double v_max, double v_backwards_max, double omega_max, double v_eps, double omega_eps)
+{
+    if (buffer_.capacity() == 0)
+        return;
+    
+    VelMeasurement measurement;
+    measurement.v = twist.twist.linear.x; // just consider linear velocity in x-direction in the robot frame for now
+    measurement.omega = twist.twist.angular.z;
+    if (measurement.v > 0 && v_max>0)
+        measurement.v /= v_max;
+    else if (measurement.v < 0 && v_backwards_max > 0)
+        measurement.v /= v_backwards_max;
+    
+    if (omega_max > 0)
+        measurement.omega /= omega_max;
+    
+    buffer_.push_back(measurement);
+
+
+    
+    // immediately compute new state
+    detect(v_eps, omega_eps);
+}
+
+void FailureDetector::clear()
+{
+    buffer_.clear();
+    oscillating_ = false;
+}
+
+bool FailureDetector::isOscillating() const
+{
+    return oscillating_;
+}
+
+bool FailureDetector::detect(double v_eps, double omega_eps)
+{
+    oscillating_ = false;
+    
+    if (buffer_.size() < buffer_.capacity()/2) // we start detecting only as soon as we have the buffer filled at least half
+        return false;
+
+    double n = (double)buffer_.size();
+            
+    // compute mean for v and omega
+    double v_mean=0;
+    double omega_mean=0;
+    int omega_zero_crossings = 0;
+    for (int i=0; i < n; ++i)
+    {
+        v_mean += buffer_[i].v;
+        omega_mean += buffer_[i].omega;
+        if ( i>0 && g2o::sign(buffer_[i].omega) != g2o::sign(buffer_[i-1].omega) )
+            ++omega_zero_crossings;
+    }
+    v_mean /= n;
+    omega_mean /= n;
+
+    if (std::abs(v_mean) < v_eps && std::abs(omega_mean) < omega_eps && omega_zero_crossings>1 ) 
+    {
+        oscillating_ = true;
+    }
+    // ROS_INFO_STREAM("v: " << std::abs(v_mean) << ", omega: " << std::abs(omega_mean) << ", zero crossings: " << omega_zero_crossings);
+    return oscillating_;
+}
+    
+    
+
+} // namespace ftc_local_planner


### PR DESCRIPTION
This PR contains the following changes:
- obstacle detection for the next n-poses
- obstacle detection with the actual robot pose and footprint
- recovery behavior if robot oscillates (seen most time in simulation with gazebo)
- new parameters for the points above and some re-ordering of existing parameters into parameter groups

There is a new topic which acts as debug output of obstacle detection. It publishes a marker array of the checked poses.
Recovery behaviour was taken from TEB Local planner

I've run the FTC in both, simulation and real mower without any crash or issue for couple of hours.