### PR TITLE
Fix FTC oscillation recovery defaults

### DIFF
--- a/cfg/FTCPlanner.cfg
+++ b/cfg/FTCPlanner.cfg
@@ -44,9 +44,9 @@ gen.add("debug_pid", bool_t, 0, " Emit debug_pid topic", False)
 grp_recovery = gen.add_group("recovery", type="tab")   
 grp_recovery.add("oscillation_recovery",   bool_t,   0,
   "Try to detect and resolve oscillations between multiple solutions in the same equivalence class (robot frequently switches between left/right/forward/backwards).",
-  True) 
-grp_recovery.add("oscillation_v_eps", double_t, 0, "Oscillation velocity eps", 5.0, 0.0, 100.0)
-grp_recovery.add("oscillation_omega_eps", double_t, 0, "Oscillation omega eps", 5.0, 0.0, 100.0)
+  True)
+grp_recovery.add("oscillation_v_eps", double_t, 0, "Oscillation velocity eps", 0.1, 0.0, 1.0)
+grp_recovery.add("oscillation_omega_eps", double_t, 0, "Oscillation omega eps", 0.1, 0.0, 1.0)
 grp_recovery.add("oscillation_recovery_min_duration", double_t, 0, "duration until recovery in s", 5.0, 0.0, 100.0)
 
 # Obstacles


### PR DESCRIPTION
Oscillation detection states:
  v_eps Threshold for the average normalized linear velocity in (0,1) that must not be exceded (e.g. 0.1)
  omega_eps Threshold for the average normalized angular velocity in (0,1) that must not be exceded (e.g. 0.1)